### PR TITLE
Fix image overflow on Ank iguide

### DIFF
--- a/docs/configuration/Anki.mdx
+++ b/docs/configuration/Anki.mdx
@@ -194,7 +194,7 @@ En el menú principal de Anki, en la barra de herramientas superior haga clic en
 * En la pestaña de **Apariencia**, la opción **Distracciones > Reducir el movimiento** debe estar **desactivada**. De esa forma se habilitarán animaciones y otro tipo de efectos en las tarjetas para que se vean mejor.
 * En la pestaña de **Repasos**, en la opción **Límite de estudio por adelantado** ponga `900`.
 
-<div style={{display: "flex", justifyContent: "space-evenly", overflow: "auto"}}>
+<div style={{display: "flex", justifyContent: "space-evenly", flexWrap: "wrap"}}>
 <img className="shadow" src={AnkiPreferencesAppearance} width="400" />
 <img className="shadow" src={AnkiPreferencesReviews} width="400" />
 </div>

--- a/docs/configuration/Anki.mdx
+++ b/docs/configuration/Anki.mdx
@@ -194,7 +194,7 @@ En el menú principal de Anki, en la barra de herramientas superior haga clic en
 * En la pestaña de **Apariencia**, la opción **Distracciones > Reducir el movimiento** debe estar **desactivada**. De esa forma se habilitarán animaciones y otro tipo de efectos en las tarjetas para que se vean mejor.
 * En la pestaña de **Repasos**, en la opción **Límite de estudio por adelantado** ponga `900`.
 
-<div style={{display: "flex", justifyContent: "space-evenly"}}>
+<div style={{display: "flex", justifyContent: "space-evenly", overflow: "auto"}}>
 <img className="shadow" src={AnkiPreferencesAppearance} width="400" />
 <img className="shadow" src={AnkiPreferencesReviews} width="400" />
 </div>


### PR DESCRIPTION
Mobile version of Anki guide adds padding on the right due to two images not having correct overflow (horizontal scrollbar) on small screens.